### PR TITLE
Remove mandatory use of an appname + other changes

### DIFF
--- a/internal/parser_test.go
+++ b/internal/parser_test.go
@@ -194,7 +194,7 @@ func TestParser_parseArgs(t *testing.T) {
 	tests := []struct {
 		name   string
 		parser parser
-		want   MainCommmands
+		want   Commands
 		want1  []SubCommand
 		want2  []string
 	}{
@@ -205,7 +205,7 @@ func TestParser_parseArgs(t *testing.T) {
 			want1: []SubCommand{
 				{
 					Name:     "vanilla",
-					Command:  "",
+					Commands: []string{""},
 					Override: false,
 					Parallel: true,
 					Exclude:  false,
@@ -235,7 +235,7 @@ func TestParser_parseArgs(t *testing.T) {
 			}
 			p.parseGadget("cpp")
 
-			got, _, got2, _ := p.parseArgs()
+			got, _, got2, _, _ := p.parseArgs()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Parser.parseArgs() got = %v, want %v", got, tt.want)
 			}

--- a/internal/root_test.go
+++ b/internal/root_test.go
@@ -71,7 +71,7 @@ func TestApp_runMainCommands(t *testing.T) {
 		spinner  *spinner.Spinner
 	}
 	type args struct {
-		mainCommands MainCommmands
+		mainCommands Commands
 	}
 	a := app{
 		filename: "cpp",
@@ -113,13 +113,13 @@ func TestApp_runMainCommands(t *testing.T) {
 			os.Stdout = os.NewFile(uintptr(syscall.Stdin), os.DevNull)
 
 			app := &App{
-				filename: tt.app.filename,
-				appName:  tt.app.appName,
-				parser:   tt.app.parser,
-				spinner:  tt.app.spinner,
+				gadget:  tt.app.filename,
+				appname: tt.app.appName,
+				parser:  tt.app.parser,
+				spinner: tt.app.spinner,
 			}
 
-			got, err := app.runMainCommands(tt.args.mainCommands)
+			got, err := app.runCommands(tt.args.mainCommands)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("App.runMainCommands() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -158,8 +158,8 @@ func TestApp_executeSubCommand(t *testing.T) {
 			fields: a,
 			args: args{
 				command: SubCommand{
-					Name:    "test",
-					Command: "some_command",
+					Name:     "test",
+					Commands: []string{"some_command"},
 				},
 			},
 			wantErr: true,
@@ -169,8 +169,8 @@ func TestApp_executeSubCommand(t *testing.T) {
 			fields: a,
 			args: args{
 				command: SubCommand{
-					Name:    "echo",
-					Command: "echo test",
+					Name:     "echo",
+					Commands: []string{"echo test"},
 				},
 			},
 			wantErr: false,
@@ -184,10 +184,10 @@ func TestApp_executeSubCommand(t *testing.T) {
 			os.Stdout = os.NewFile(uintptr(syscall.Stdin), os.DevNull)
 
 			app := &App{
-				filename: tt.fields.filename,
-				appName:  tt.fields.appName,
-				parser:   tt.fields.parser,
-				spinner:  tt.fields.spinner,
+				gadget:  tt.fields.filename,
+				appname: tt.fields.appName,
+				parser:  tt.fields.parser,
+				spinner: tt.fields.spinner,
 			}
 			if err := app.executeSubCommand(tt.args.command); (err != nil) != tt.wantErr {
 				t.Errorf("App.executeSubCommand() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
### New:
- Add gadget property `chdir` that, when true, after the main gadget commands are ran and also use the \_APPNAME placeholder to create a project directory, changes directory inside the \_APPNAME directory executes the rest from inside that directory.

### Changed:
- Providing a name for your project is now optional and is done through the \_APPNAME placeholder.
- Subcommands can now execute multiple commands aswell
- Subcommands `command` property renamed to `commands`
- Override property on subcommands now overrides the whole commands array instead of the last command

### Removed:
- Template property from gadgets